### PR TITLE
Make PDF decryption reproducible so re-consumed mails are recognised as duplicates

### DIFF
--- a/scripts/decrypt-pdf
+++ b/scripts/decrypt-pdf
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
-# Normalises volatile PDF metadata so a document re-sent by the origin lands on
-# the same checksum and Paperless rejects it as a duplicate.
+# Makes decryption reproducible so the same attachment always yields the same
+# checksum and Paperless can recognise a re-consumed mail as a duplicate.
 #
-# Some payroll systems generate the PDF once but stamp a fresh /ModDate on every
-# dispatch; the trailer /ID is derived from it. Two byte-identical documents
-# then differ in exactly those fields, so both get consumed. Dropping /ModDate
-# and writing a content-derived /ID makes them identical again. /CreationDate,
-# page content and XMP stay untouched.
+# qpdf rewrites the file on decryption and assigns a fresh /ID[1] - the PDF
+# trailer identifier that changes on every write. If the same mail is consumed
+# twice (e.g. it was delivered twice and shows up under two IMAP UIDs), the two
+# decrypted copies differ in exactly that field, so duplicate detection fails
+# and both documents are kept. Writing a content-derived /ID instead makes the
+# output byte-identical across runs. Nothing else about the file is changed.
 normalize_pdf() {
     python3 - "$1" <<'PY'
 import sys
@@ -22,13 +23,9 @@ path = sys.argv[1]
 
 try:
     pdf = pikepdf.open(path, allow_overwriting_input=True)
-    dropped = False
-    if pdf.docinfo is not None and "/ModDate" in pdf.docinfo:
-        del pdf.docinfo["/ModDate"]
-        dropped = True
     pdf.save(path, deterministic_id=True)
     pdf.close()
-    print("Normalised: %s/ID made deterministic" % ("/ModDate removed, " if dropped else ""))
+    print("Normalised: /ID made deterministic")
 except Exception as exc:  # never block consumption on this
     print("Normalisation skipped: %s" % exc)
 PY

--- a/scripts/decrypt-pdf
+++ b/scripts/decrypt-pdf
@@ -1,5 +1,39 @@
 #!/usr/bin/env bash
 
+# Normalises volatile PDF metadata so a document re-sent by the origin lands on
+# the same checksum and Paperless rejects it as a duplicate.
+#
+# Some payroll systems generate the PDF once but stamp a fresh /ModDate on every
+# dispatch; the trailer /ID is derived from it. Two byte-identical documents
+# then differ in exactly those fields, so both get consumed. Dropping /ModDate
+# and writing a content-derived /ID makes them identical again. /CreationDate,
+# page content and XMP stay untouched.
+normalize_pdf() {
+    python3 - "$1" <<'PY'
+import sys
+
+try:
+    import pikepdf
+except ImportError:
+    print("pikepdf unavailable, skipping normalisation")
+    sys.exit(0)
+
+path = sys.argv[1]
+
+try:
+    pdf = pikepdf.open(path, allow_overwriting_input=True)
+    dropped = False
+    if pdf.docinfo is not None and "/ModDate" in pdf.docinfo:
+        del pdf.docinfo["/ModDate"]
+        dropped = True
+    pdf.save(path, deterministic_id=True)
+    pdf.close()
+    print("Normalised: %s/ID made deterministic" % ("/ModDate removed, " if dropped else ""))
+except Exception as exc:  # never block consumption on this
+    print("Normalisation skipped: %s" % exc)
+PY
+}
+
 # Check if the file is encrypted
 encryption_info=$(qpdf --show-encryption "${DOCUMENT_WORKING_PATH}" 2>&1)
 
@@ -15,6 +49,7 @@ else
         # Try to decrypt the file with the current password
         if qpdf --decrypt --replace-input --password="$password" "${DOCUMENT_WORKING_PATH}" >/dev/null 2>&1; then
             echo "Decryption successful with provided password"
+            normalize_pdf "${DOCUMENT_WORKING_PATH}"
             exit 0  # Exit the script here since decryption was successful
         else
             echo "Decryption failed with provided password"


### PR DESCRIPTION
## Symptom

Payslips land in Paperless twice. Other documents don't.

## Root cause

Not a double send — the origin sends once. In every affected month the mailbox holds **one** mail: one Message-ID, one byte-identical attachment.

```
2025-09 … 2026-05:   1 Message-ID, 1 attachment hash
2026-07:             2 Message-IDs, 2 attachment hashes  (genuine correction mail)
```

Paperless consumed that single mail twice because it showed up under two IMAP UIDs — visible in `paperless_mail_processedmail`, where both rows carry the **same** `received` timestamp:

```
uid 52689  received 2026-02-06 14:15:53   processed 14:20
uid 52691  received 2026-02-06 14:15:53   processed 14:25
```

That alone would be harmless: the second copy is identical, so duplicate detection should reject it. It doesn't, because `qpdf --decrypt --replace-input` rewrites the file and assigns a fresh `/ID[1]` — the trailer identifier that changes on every write. Comparing the two stored documents:

```
/ID[0]  (permanent, set at creation)   identical in every pair
/ID[1]  (changes on every write)       different in every pair
/ModDate                               identical in every pair
```

Two decryption runs over the same attachment therefore produce two different checksums, and both documents are kept.

## Change

Write a content-derived `/ID` after decryption via `pikepdf(deterministic_id=True)`, so the same attachment always yields the same bytes.

Scope is limited to encrypted PDFs — the script already returns early for everything else. Normalisation runs in a `try/except` and prints instead of failing, so it can never block consumption; a missing `pikepdf` degrades to a no-op. Nothing else about the file is touched.

## Verification

Against the real payslip, encrypted to reproduce the arrival state, running the patched script as `PAPERLESS_PRE_CONSUME_SCRIPT`:

| case | result |
|---|---|
| same mail consumed twice | `670cc52ff2e8…` / `670cc52ff2e8…` — identical, duplicate rejected |
| July correction mail | `97e02a3ea398…` — still distinct, stays its own document |

The second row matters: the fix must not collapse the corrected payslip into the original. It doesn't, because the attachments genuinely differ.

An earlier revision of this PR also removed `/ModDate`. That was based on a misreading of the July pair and is not needed — `/ModDate` is identical in every real duplicate. Dropped again to keep the diff minimal.

## Out of scope

- Documents already duplicated in the archive need manual cleanup. Note that the July pair is **not** a duplicate.
- Why the mail appears under two UIDs is unresolved; this change makes the pipeline resilient to it either way.