### PR TITLE
Dateinamensformat auf Jinja-Syntax umstellen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ PAPERLESS_TIME_ZONE=Europe/Berlin
 # documents are written in.
 PAPERLESS_OCR_LANGUAGE=deu
 
-PAPERLESS_FILENAME_FORMAT={created_year}/{correspondent}/{created}-{asn}-{title}
+PAPERLESS_FILENAME_FORMAT={{ created_year }}/{{ correspondent }}/{{ created }}-{{ asn }}-{{ title }}
 PAPERLESS_CONSUMER_ENABLE_BARCODES=true
 
 # External server ip


### PR DESCRIPTION
Paperless warnt bei jedem Kommando:

```
Filename format {created_year}/{correspondent}/{created}-{title} is using the old
style, please update to use double curly brackets
```

Die alte Schreibweise wird noch unterstuetzt, ist aber abgekuendigt. Die neue erzeugt dieselben Pfade — es werden keine Dateien verschoben.

Betrifft nur `.env.example`; der tatsaechliche Wert steht in der lokalen `.env` und muss dort separat nachgezogen werden.