### PR TITLE
paperless-gpt danebenstellen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,11 @@ SFTP_PASSWORD=
 PAPERLESS_DECRYPT_PASSWORD="test test123"
 
 CADDY_DOMAIN=documents.your-domain.de
+# paperless-gpt - Vorschlaege fuer Titel, Tags und Absender mit Ansichtsseite.
+# Arbeitet tagbasiert: nur Dokumente mit dem Tag "paperless-gpt" werden
+# vorgeschlagen, "paperless-gpt-auto" wird ohne Rueckfrage uebernommen.
+GPT_PAPERLESS_TOKEN=
+GPT_LLM_ENDPOINT=
+GPT_LLM_MODEL=
+GPT_LLM_API_KEY=
+GPT_CADDY_DOMAIN=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,34 @@ services:
       app_cache:
       caddy:
 
+  gpt:
+    image: icereed/paperless-gpt:latest
+    restart: unless-stopped
+    depends_on:
+      - app
+    volumes:
+      - gpt_prompts:/app/prompts
+    environment:
+      - PAPERLESS_BASE_URL=http://app:8000
+      - PAPERLESS_API_TOKEN=${GPT_PAPERLESS_TOKEN}
+      - PAPERLESS_PUBLIC_URL=${PAPERLESS_URL}
+      # OpenAI-kompatibler Endpunkt, kein OpenAI - siehe OPENAI_BASE_URL
+      - LLM_PROVIDER=openai
+      - LLM_MODEL=${GPT_LLM_MODEL}
+      - OPENAI_API_KEY=${GPT_LLM_API_KEY}
+      - OPENAI_BASE_URL=${GPT_LLM_ENDPOINT}
+      - LLM_LANGUAGE=German
+      # Der Endpunkt drosselt frueh; Standard waere 120.
+      - LLM_REQUESTS_PER_MINUTE=${GPT_LLM_RPM:-20}
+      - SUGGESTION_WORKERS=1
+      - LOG_LEVEL=info
+      - CADDY_DOMAIN=${GPT_CADDY_DOMAIN}
+      - CADDY_TYPE=${GPT_CADDY_TYPE:-internal}
+      - CADDY_PORT=8080
+    networks:
+      default:
+      caddy:
+
   sftp:
     image: ghcr.io/hueske-digital/sftp:latest
     restart: unless-stopped
@@ -119,6 +147,7 @@ networks:
 
 volumes:
   app_data:
+  gpt_prompts:
   app_media:
   db_data:
   redis_data:


### PR DESCRIPTION
[icereed/paperless-gpt](https://github.com/icereed/paperless-gpt) zum Ausprobieren neben der eingebauten KI.

## Warum es sich nicht beisst

paperless-gpt arbeitet **tagbasiert**: Es fasst nur Dokumente mit dem Tag `paperless-gpt` (Vorschlag zur Ansicht) oder `paperless-gpt-auto` (ohne Rueckfrage) an. Beide Tags legt es beim Start selbst an. Solange sie nicht vergeben werden, passiert nichts — das Post-Consume-Skript bleibt also unberuehrt.

## Konfiguration

Der Endpunkt wird ueber `OPENAI_BASE_URL` angesprochen. Der Anbieter heisst `openai`, das Feld ist laut Dokumentation aber ausdruecklich fuer OpenAI-kompatible Endpunkte gedacht (OpenRouter, LiteLLM, vLLM).

`LLM_REQUESTS_PER_MINUTE` steht auf 20 statt der voreingestellten 120, und `SUGGESTION_WORKERS` auf 1 — bei drei parallelen Anfragen lief unser eigener Lauf heute reihenweise in HTTP 429.

Die Oberflaeche laeuft auf Port 8080 und wird ueber die vorhandenen Caddy-Variablen eingebunden, voreingestellt `internal`.

## Vor dem Start noetig

In der `.env` zu setzen — die Namen stehen jetzt in `.env.example`:

```
GPT_PAPERLESS_TOKEN=   # in Paperless unter Einstellungen erzeugen
GPT_LLM_ENDPOINT=      # derselbe wie bei der eingebauten KI
GPT_LLM_MODEL=
GPT_LLM_API_KEY=
GPT_CADDY_DOMAIN=
```

Die Prompts liegen im Volume `gpt_prompts` und lassen sich spaeter anpassen.