### PR TITLE
Titel automatisch von paperless-gpt vergeben lassen

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,9 @@ services:
       - PAPERLESS_FILENAME_FORMAT_REMOVE_NONE=true
       - PAPERLESS_DECRYPT_PASSWORD
       - PAPERLESS_PRE_CONSUME_SCRIPT=/usr/local/bin/scripts/decrypt-pdf
-      - PAPERLESS_POST_CONSUME_SCRIPT=/usr/local/bin/scripts/post-consume
+      # Abgeschaltet: paperless-gpt vergibt die Titel jetzt automatisch.
+      # Beide gleichzeitig wuerden sich beim Titel widersprechen.
+      # - PAPERLESS_POST_CONSUME_SCRIPT=/usr/local/bin/scripts/post-consume
       - KI_EMPFAENGER
       - CADDY_DOMAIN=${CADDY_DOMAIN}
       - CADDY_TYPE=${CADDY_TYPE:-internal}
@@ -94,6 +96,14 @@ services:
       - OPENAI_API_KEY=${GPT_LLM_API_KEY}
       - OPENAI_BASE_URL=${GPT_LLM_ENDPOINT}
       - LLM_LANGUAGE=German
+      # Ohne Rueckfrage nur Titel und Typ. Der Typ ist laut Doku auf die
+      # vorhandenen Typen beschraenkt. Absender und Tags bleiben beim
+      # Klassifikator - paperless-gpt wuerde neue Absender anlegen.
+      - AUTO_GENERATE_TITLE=true
+      - AUTO_GENERATE_DOCUMENT_TYPE=true
+      - AUTO_GENERATE_TAGS=false
+      - AUTO_GENERATE_CORRESPONDENTS=false
+      - AUTO_GENERATE_CREATED_DATE=false
       # Der Endpunkt drosselt frueh; Standard waere 120.
       - LLM_REQUESTS_PER_MINUTE=${GPT_LLM_RPM:-20}
       - SUGGESTION_WORKERS=1


### PR DESCRIPTION
Alles, was im Posteingang landet, bekommt ohne Zutun einen Titel.

## Was sich aendert

| Feld | wer macht es |
|---|---|
| Titel | paperless-gpt, ohne Rueckfrage |
| Dokumenttyp | paperless-gpt, beschraenkt auf vorhandene Typen |
| Absender | Klassifikator wie bisher |
| Tags | Klassifikator wie bisher |
| Datum | Paperless wie bisher |

Absender bleiben bewusst aus: Der Prompt von paperless-gpt erlaubt ausdruecklich neue Absender ("either from the example list or come up with a new correspondent") und weist an, Rechtsformen wegzulassen — neben `EnBW Energie Baden-Wuerttemberg AG` entstuende so ein zweites `EnBW`.

Der Dokumenttyp dagegen ist im Prompt hart gebunden: *"Only select a document type from the provided list. If none of the available document types fit, respond with an empty string."*

## Post-Consume-Skript abgeschaltet

Zwei Systeme, die beide den Titel setzen, wuerden sich widersprechen. Der Hook ist auskommentiert, die Skripte bleiben im Repo — der Weg zurueck ist damit ein Entfernen des Kommentarzeichens.

## Noch noetig

Ein Workflow in paperless-ngx: Ausloeser *Dokument hinzugefuegt*, Aktion *Zuweisung* mit Tag `paperless-gpt-auto`. Den lege ich separat an, er steht nicht im Repo.